### PR TITLE
GUI Applications fail in Wayland

### DIFF
--- a/usr/sbin/orjail
+++ b/usr/sbin/orjail
@@ -92,7 +92,7 @@ printvn() {
 # Ex.    orjail ls "/tmp/a\\ b" # systems with su but without sudo
 run () {
   if [ "$SUDOBIN" ]; then
-    $SUDOBIN -u "$USERNAME" "$@"
+    $SUDOBIN -u "$USERNAME" --preserve-env=XDG_RUNTIME_DIR,WAYLAND_DISPLAY "$@"
   else
     su "$USERNAME" -c "$*"
   fi


### PR DESCRIPTION
Under Wayland it seems to be impossible to start a GUI application with orjail.
When I modify the run() function to preserve certain env variables it works.