### PR TITLE
archlinux fix

### DIFF
--- a/usr/sbin/orjail
+++ b/usr/sbin/orjail
@@ -555,7 +555,6 @@ if ! ip netns list | eno grep \\b"$NAME"\\b; then
   print G " * Tor version is $TORVERSION"
 
   TORCONFIGFILE=$(mktemp /tmp/torXXXXXX)
-  chown "$USERNAME" "$TORCONFIGFILE"
   if [ "$HOSTTORRC" = "y" ] && [ -f /etc/tor/torrc ]; then
     echo '%include /etc/tor/torrc' >> "$TORCONFIGFILE"
   fi
@@ -581,6 +580,10 @@ EOF
       echo "HiddenServiceVersion 3" >> "$TORCONFIGFILE";
       echo "HiddenServicePort $HSERVICEPORT $IPNETNS:$HSERVICEPORT"; } >> "$TORCONFIGFILE"
   fi
+  
+  # this chown causes issues in archlinux where tmpfs seems to be protected...
+  # so call this only after the config file is ready. see PR#71
+  chown "$USERNAME" "$TORCONFIGFILE"
 
   # reuse tor host's cache
   if [ -d "/var/lib/tor" ]; then


### PR DESCRIPTION
to replicate it (change just USERNAME with an existing user):
```bash
USERNAME="castix"

function mktemptest {
    echo "with $1"
    ls -al $1
    file $1
    cat $1
    ls -al $1
    echo "ok" > $1
    echo "ok"
    chown $USERNAME $1
    chmod 777 $1
    ls -al $1
    echo "okok" > $1
    echo "okok"
    echo
    rm $1
}

mktemptest $(mktemp)
mktemptest $(touch here; echo here)
mktemptest $(touch /tmp/here; echo /tmp/here)
ls -ld /tmp
```
then as root (su or sudo) run it sudo bash test
my output is
```
with /tmp/tmp.V8KOHGTLPe
-rw------- 1 root root 0 Jun 22 20:45 /tmp/tmp.V8KOHGTLPe
/tmp/tmp.V8KOHGTLPe: empty
-rw------- 1 root root 0 Jun 22 20:45 /tmp/tmp.V8KOHGTLPe
ok
-rwxrwxrwx 1 castix root 3 Jun 22 20:45 /tmp/tmp.V8KOHGTLPe
test: line 14: /tmp/tmp.V8KOHGTLPe: Permission denied
okok

with here
-rw-r--r-- 1 root root 0 Jun 22 20:45 here
here: empty
-rw-r--r-- 1 root root 0 Jun 22 20:45 here
ok
-rwxrwxrwx 1 castix root 3 Jun 22 20:45 here
okok

with /tmp/here
-rw-r--r-- 1 root root 0 Jun 22 20:45 /tmp/here
/tmp/here: empty
-rw-r--r-- 1 root root 0 Jun 22 20:45 /tmp/here
ok
-rwxrwxrwx 1 castix root 3 Jun 22 20:45 /tmp/here
test: line 14: /tmp/here: Permission denied
okok

drwxrwxrwt 13 root root 540 Jun 22 20:45 /tmp
```
as you can see it says permission denied (even with chmod 777)
if I run it without root privileges it will execute fine.

tried it also across reboot, and more interesting tried also in raspbian and here's the output
```
root@biancucia:/home/pi# bash test
with /tmp/tmp.c2cTpdah83
-rw------- 1 root root 0 Jun 22 19:35 /tmp/tmp.c2cTpdah83
/tmp/tmp.c2cTpdah83: empty
-rw------- 1 root root 0 Jun 22 19:35 /tmp/tmp.c2cTpdah83
ok
-rwxrwxrwx 1 pi root 3 Jun 22 19:35 /tmp/tmp.c2cTpdah83
okok

with here
-rw-r--r-- 1 root root 0 Jun 22 19:35 here
here: empty
-rw-r--r-- 1 root root 0 Jun 22 19:35 here
ok
-rwxrwxrwx 1 pi root 3 Jun 22 19:35 here
okok

with /tmp/here
-rw-r--r-- 1 root root 0 Jun 22 19:35 /tmp/here
/tmp/here: empty
-rw-r--r-- 1 root root 0 Jun 22 19:35 /tmp/here
ok
-rwxrwxrwx 1 pi root 3 Jun 22 19:35 /tmp/here
okok

drwxrwxrwt 9 root root 4096 Jun 22 19:35 /tmp
```
for completeness here's `uname -a` 
`Linux triangolo 5.7.3-arch1-1 #1 SMP PREEMPT Wed, 17 Jun 2020 19:42:12 +0000 x86_64 GNU/Linux`

so, write the config file, then set the owner