### PR TITLE
Resolve binary path for firejail arg

### DIFF
--- a/usr/sbin/orjail
+++ b/usr/sbin/orjail
@@ -651,14 +651,15 @@ fi
 NOSETUPERROR=y
 # use firejail as security container
 if [ $USEFIREJAIL = y ]; then
+  BINARYPATH="$(readlink -f $(which "$@"))"
   # shellcheck disable=SC2068
   if [ $NAMESPACE_EXIST = y ]; then
-    run "$FIREJAILBIN" ${FIREJAILARGS[@]} --join="$NAME" "$@"
+    run "$FIREJAILBIN" ${FIREJAILARGS[@]} --join="$NAME" "$BINARYPATH"
   else
     run "$FIREJAILBIN" \
       --quiet --dns="$IPHOST" --name="$NAME" --netns="$NAME" \
       --hostname=host --noroot --private-tmp --private-dev \
-      ${FIREJAILARGS[@]} "$@"
+      ${FIREJAILARGS[@]} "$BINARYPATH"
   fi
 else #or without
   if [ $NAMESPACE_EXIST = y ]; then


### PR DESCRIPTION
Hey,
when using `orjail` with firejail enabled like this I get following error on NixOS:
```
$ sudo orjail -f chromium
Error: no suitable chromium executable found
```
On NixOS the command `chromium` has the following path:
```
$ which chromium
/home/onny/.nix-profile/bin/chromium
```
But this is a symlink to a different path
```
$ readlink -f /home/onny/.nix-profile/bin/chromium
/nix/store/vbvrcmz9rp6vz8dbylki19irkask5gn7-chromium-97.0.4692.99/bin/chromium
``` 
If I supply the absolute path, starting `chromium` with `orjail` and firejail enabled works.

This PR uses both commands to resolve the absolute path and uses it as argument for the firejail command.